### PR TITLE
Make Kubernetes specific env variables available when joining a cluster via SSH

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -13,7 +13,7 @@ urllib3 = None
 
 LOCAL_PORT_FOR_PORT_FORWARD = 23100
 PORT_FORWARD_PROXY_CMD_TEMPLATE = 'kubernetes-port-forward-proxy-command.yaml.j2'
-PORT_FORWARD_PROXY_CMD_PATH = '~/.sky/port-forward-proxy-cmd.sh'
+PORT_FORWARD_PROXY_CMD_PATH = '~/.sky/port-forward-proxy-cmd-{cluster_name}.sh'
 
 _configured = False
 _core_api = None

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -39,6 +39,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky import spot as spot_lib
 from sky import status_lib
+from sky.adaptors import kubernetes
 from sky.backends import onprem_utils
 from sky.skylet import constants
 from sky.skylet import log_lib
@@ -709,6 +710,12 @@ class SSHConfigHelper(object):
             docker_user: If not None, use this user to ssh into the docker
         """
         username = auth_config['ssh_user']
+        port_forward_proxy_cmd_path = os.path.expanduser(
+            kubernetes.PORT_FORWARD_PROXY_CMD_PATH.format(
+                cluster_name=cluster_name))
+        if os.path.exists(port_forward_proxy_cmd_path):
+            os.remove(port_forward_proxy_cmd_path)
+
         config_path = os.path.expanduser(cls.ssh_conf_path)
         if not os.path.exists(config_path):
             return

--- a/sky/templates/kubernetes-port-forward-proxy-command.yaml.j2
+++ b/sky/templates/kubernetes-port-forward-proxy-command.yaml.j2
@@ -4,7 +4,7 @@ set -uo pipefail
 
 # Ignore this function and `e home` if you use something like `kubectx` to manage your kubectl contexts and environments
 e(){
-    export KUBECONFIG="/home/gcpuser/.kube/config"
+    export KUBECONFIG="/home/`whoami`/.kube/config"
 }
 
 e home
@@ -16,6 +16,10 @@ if [ $? -eq 0 ]; then
     pkill -f "kubectl port-forward svc/{{ ssh_jump_name }} {{ local_port }}:22"
 fi
 
+POD_NAME=$(kubectl get pods --selector=skypilot-cluster={{ cluster_name }},ray-node-type=head -o jsonpath='{.items[0].metadata.name}' 2> /dev/null)
+if ! [ -z "$POD_NAME" ]; then
+    kubectl exec $POD_NAME -- bash -c "printenv > /home/sky/.k8s_env" 2> /dev/null
+fi
 kubectl port-forward svc/{{ ssh_jump_name }} {{ local_port }}:22 &
 K8S_PID=$!
 trap "kill -9 $K8S_PID" EXIT

--- a/sky/templates/kubernetes-port-forward-proxy-command.yaml.j2
+++ b/sky/templates/kubernetes-port-forward-proxy-command.yaml.j2
@@ -9,6 +9,15 @@ e(){
 
 e home
 
+POD_NAME=$(kubectl get pods --selector=skypilot-cluster={{ cluster_name }},ray-node-type=head -o jsonpath='{.items[0].metadata.name}' 2> /dev/null)
+if ! [ -z "$POD_NAME" ]; then
+    kubectl exec $POD_NAME -- bash -c "printenv > /home/sky/.k8s_env" 2> /dev/null
+fi
+
+if [ {{ is_nodeport_enabled }} -eq 1 ]; then
+    exit 0
+fi
+
 pgrep -f "kubectl port-forward svc/{{ ssh_jump_name }} {{ local_port }}:22" > /dev/null
 
 # If the command is running, kill it
@@ -16,10 +25,6 @@ if [ $? -eq 0 ]; then
     pkill -f "kubectl port-forward svc/{{ ssh_jump_name }} {{ local_port }}:22"
 fi
 
-POD_NAME=$(kubectl get pods --selector=skypilot-cluster={{ cluster_name }},ray-node-type=head -o jsonpath='{.items[0].metadata.name}' 2> /dev/null)
-if ! [ -z "$POD_NAME" ]; then
-    kubectl exec $POD_NAME -- bash -c "printenv > /home/sky/.k8s_env" 2> /dev/null
-fi
 kubectl port-forward svc/{{ ssh_jump_name }} {{ local_port }}:22 &
 K8S_PID=$!
 trap "kill -9 $K8S_PID" EXIT

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -272,6 +272,8 @@ setup_commands:
     pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc);
     (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
     (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
+    touch /home/sky/.k8s_env;
+    sudo ln -sf ~/.k8s_env /etc/environment;
     {{ conda_installation_commands }}
     source ~/.bashrc;
     mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && touch ~/.sudo_as_admin_successful;


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This enables K8s specific env vars to be available in an SSH session. It does this by:
- Creating a .k8s_env file and symlinking it to /etc/environment during setup.
- Running `kubectl exec {pod_name} --  env` as part of SSH Proxy command and saving env vars to the .k8s_env file
- Creating a separate bash script for ProxyCommand per cluster and handling cleanup during teardown

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
